### PR TITLE
fix(ws): Don't respond to ping/keepalive

### DIFF
--- a/twitch_tohell/src/websocket/client.rs
+++ b/twitch_tohell/src/websocket/client.rs
@@ -320,9 +320,9 @@ where
                 Err(e)
             }
         },
-        Some(Ok(Message::Ping(ping))) => {
-            trace!("received ping, sending pong");
-            write.send(Message::Pong(ping)).await?;
+        Some(Ok(Message::Ping(_))) => {
+            // pong handled by tungstenite for us
+            trace!("received ping");
             Ok(None)
         }
         Some(Ok(Message::Close(frame))) => {
@@ -347,7 +347,7 @@ where
 }
 
 async fn handle_text_message<S>(
-    write: &mut WsSink,
+    _write: &mut WsSink,
     svc: &mut S,
     text: Utf8Bytes,
 ) -> Result<Option<String>, Error>
@@ -357,9 +357,8 @@ where
     let req = Request::from_str(&text)?;
 
     if req.is_keepalive() {
-        trace!("received keepalive, sending pong");
-        write.send(Message::Pong("".into())).await?;
-
+        // Twitch does not expect any response from keepalive messages
+        trace!("received keepalive");
         return Ok(None);
     }
 
@@ -369,11 +368,19 @@ where
     }
     svc.ready().await.expect("service error is Infallible");
 
+    let req_sub_type = req.subscription_type;
     let resp = svc.call(req).await.expect("service error is Infallible");
 
     if resp.is_reconnect() {
         trace!("handler requested reconnect");
         return Ok(resp.url);
+    }
+
+    if resp.is_error() {
+        warn!(
+            "handler error for {:?}: type={:?} reason={:?}",
+            req_sub_type, resp.error_type, resp.error_reason
+        );
     }
 
     Ok(None)


### PR DESCRIPTION
Tunstenite already handles the ping for the websocket protocol, so there's no need for us to respond. Also snuck in a warning log for any handler errors

https://github.com/snapview/tungstenite-rs/blob/c2921718b76f0ed8c69a895397ed981e4a321f6f/src/protocol/mod.rs#L668-L675

